### PR TITLE
Set the store_id on the product object before the generation

### DIFF
--- a/Iazel/RegenProductUrl/Console/Command/RegenerateProductUrlCommand.php
+++ b/Iazel/RegenProductUrl/Console/Command/RegenerateProductUrlCommand.php
@@ -84,6 +84,7 @@ class RegenerateProductUrlCommand extends Command
                 UrlRewrite::STORE_ID => $store_id
             ]);
             try {
+                $product->setStoreId($store_id);
                 $this->urlPersist->replace(
                     $this->productUrlRewriteGenerator->generate($product)
                 );


### PR DESCRIPTION
In Magento 2.1.1 and for a product that is part of many stores, although the proper UrlPath is loaded during the collection loading, the StoreId on the product is the first one (let's say store id the product belongs in are 1,2,3 and all have different languages and you request the generation for id = 3) so it generates the url using the Url Key for store_id 3 and saves it in the db for store_id = 1.