### PR TITLE
Fixes Iazel/magento2-regenurl#11 & Iazel/magento2-regenurl#13

### DIFF
--- a/Iazel/RegenProductUrl/Console/Command/RegenerateProductUrlCommand.php
+++ b/Iazel/RegenProductUrl/Console/Command/RegenerateProductUrlCommand.php
@@ -11,6 +11,7 @@ use Magento\UrlRewrite\Model\UrlPersistInterface;
 use Magento\CatalogUrlRewrite\Model\ProductUrlRewriteGenerator;
 use Magento\Catalog\Model\ResourceModel\Product\Collection;
 use Magento\Store\Model\Store;
+use Magento\Framework\App\State;
 
 class RegenerateProductUrlCommand extends Command
 {
@@ -29,15 +30,18 @@ class RegenerateProductUrlCommand extends Command
      */
     protected $collection;
 
+    /**
+     * @var \Magento\Framework\App\State
+     */
+    protected $state;
+
     public function __construct(
-        \Magento\Framework\App\State $state,
+        State $state,
         Collection $collection,
         ProductUrlRewriteGenerator $productUrlRewriteGenerator,
         UrlPersistInterface $urlPersist
     ) {
-        if (!$state->getAreaCode()) {
-            $state->setAreaCode('adminhtml');
-        }
+        $this->state = $state;
         $this->collection = $collection;
         $this->productUrlRewriteGenerator = $productUrlRewriteGenerator;
         $this->urlPersist = $urlPersist;
@@ -65,6 +69,10 @@ class RegenerateProductUrlCommand extends Command
 
     public function execute(InputInterface $inp, OutputInterface $out)
     {
+        if (!$this->state->getAreaCode()) {
+            $this->state->setAreaCode('adminhtml');
+        }
+
         $store_id = $inp->getOption('store');
         $this->collection->addStoreFilter($store_id)->setStoreId($store_id);
 

--- a/Iazel/RegenProductUrl/Console/Command/RegenerateProductUrlCommand.php
+++ b/Iazel/RegenProductUrl/Console/Command/RegenerateProductUrlCommand.php
@@ -35,7 +35,9 @@ class RegenerateProductUrlCommand extends Command
         ProductUrlRewriteGenerator $productUrlRewriteGenerator,
         UrlPersistInterface $urlPersist
     ) {
-        $state->setAreaCode('adminhtml');
+        if (!$state->getAreaCode()) {
+            $state->setAreaCode('adminhtml');
+        }
         $this->collection = $collection;
         $this->productUrlRewriteGenerator = $productUrlRewriteGenerator;
         $this->urlPersist = $urlPersist;


### PR DESCRIPTION
Avoids the LocalizedException error message 'Area code is already set'
by first checking to see if the area code is set or not. If area code is
not set, then set it to 'adminhtml'