### PR TITLE
Allow running the command once again

### DIFF
--- a/Iazel/RegenProductUrl/Console/Command/RegenerateProductUrlCommand.php
+++ b/Iazel/RegenProductUrl/Console/Command/RegenerateProductUrlCommand.php
@@ -6,6 +6,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\UrlRewrite\Service\V1\Data\UrlRewrite;
 use Magento\UrlRewrite\Model\UrlPersistInterface;
 use Magento\CatalogUrlRewrite\Model\ProductUrlRewriteGenerator;
@@ -69,8 +70,11 @@ class RegenerateProductUrlCommand extends Command
 
     public function execute(InputInterface $inp, OutputInterface $out)
     {
-        if (!$this->state->getAreaCode()) {
+
+        try {
             $this->state->setAreaCode('adminhtml');
+        } catch (LocalizedException $e) {
+            $out->writeln("Area code has already been set. Skipping");
         }
 
         $store_id = $inp->getOption('store');


### PR DESCRIPTION
Recently, Magneto was modified such that it throws an exception if the
area is modified during application runtime, if it has been set
previously. This extension sets it prior to regenerating the URLs.

Additional work attempted to repair this change by checking if the area
code was set. However, this has not functioned as expected (at least in
the most recent version of Magento), as Magento throws an exception on
querying an area code that has not already been set.

This commit modifies the setter such that it attempts to set the
application state during runtime, and on failure, preserves it as is.
This allows upstream to make the decision as to what state should be
set, but provides a sane fallback in the case it does not.