### PR TITLE
Allow command being executed in newer Magento versions

### DIFF
--- a/Iazel/RegenProductUrl/etc/di.xml
+++ b/Iazel/RegenProductUrl/etc/di.xml
@@ -1,12 +1,7 @@
 <?xml version="1.0"?>
-<!--
-/**
- * Copyright © 2016 Magento. All rights reserved.
- * See COPYING.txt for license details.
- */
--->
+
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
-    <type name="Magento\Framework\Console\CommandList">
+    <type name="Magento\Framework\Console\CommandListInterface">
         <arguments>
             <argument name="commands" xsi:type="array">
                 <item name="product_url_regeneration_command" xsi:type="object">Iazel\RegenProductUrl\Console\Command\RegenerateProductUrlCommand</item>


### PR DESCRIPTION
Fixes #14:

```
 [InvalidArgumentException]                                         
  There are no commands defined in the "magesetup:setup" namespace. 
```