### PR TITLE
A small fix, clearing the collection before applying filters and loading products for the next store view.

### DIFF
--- a/Iazel/RegenProductUrl/Console/Command/RegenerateCategoryPathCommand.php
+++ b/Iazel/RegenProductUrl/Console/Command/RegenerateCategoryPathCommand.php
@@ -20,17 +20,17 @@ use Magento\Framework\App\State;
 class RegenerateCategoryPathCommand extends Command
 {
     /**
-     * @var CategoryUrlPathGenerator
+     * @var CategoryUrlPathGenerator\Proxy
      */
     protected $categoryUrlPathGenerator;
 
     /**
-     * @var UrlPersistInterface
+     * @var UrlPersistInterface\Proxy
      */
     protected $urlPersist;
 
     /**
-     * @var CategoryRepositoryInterface
+     * @var CategoryRepositoryInterface\Proxy
      */
     protected $collection;
 
@@ -40,41 +40,41 @@ class RegenerateCategoryPathCommand extends Command
     protected $state;
 
     /**
-     * @var CategoryCollectionFactory
+     * @var CategoryCollectionFactory\Proxy
      */
     private $categoryCollectionFactory;
     /**
-     * @var EventManager
+     * @var EventManager\Proxy
      */
     private $eventManager;
     /**
-     * @var CategoryResource
+     * @var CategoryResource\Proxy
      */
     private $categoryResource;
     /**
-     * @var Emulation
+     * @var Emulation\Proxy
      */
     private $emulation;
 
     /**
      * RegenerateCategoryPathCommand constructor.
      * @param State $state
-     * @param CategoryCollectionFactory $categoryCollectionFactory
-     * @param CategoryUrlPathGenerator $categoryUrlPathGenerator
-     * @param UrlPersistInterface $urlPersist
-     * @param EventManager $eventManager
-     * @param CategoryResource $categoryResource
-     * @param ResourceConnection $resource
-     * @param Emulation $emulation
+     * @param CategoryCollectionFactory\Proxy $categoryCollectionFactory
+     * @param CategoryUrlPathGenerator\Proxy $categoryUrlPathGenerator
+     * @param UrlPersistInterface\Proxy $urlPersist
+     * @param EventManager\Proxy $eventManager
+     * @param CategoryResource\Proxy $categoryResource
+     * @param ResourceConnection\Proxy $resource
+     * @param Emulation\Proxy $emulation
      */
     public function __construct(
         State $state,
-        CategoryCollectionFactory $categoryCollectionFactory,
-        CategoryUrlPathGenerator $categoryUrlPathGenerator,
-        UrlPersistInterface $urlPersist,
-        EventManager $eventManager,
-        CategoryResource $categoryResource,
-        Emulation $emulation
+        CategoryCollectionFactory\Proxy $categoryCollectionFactory,
+        CategoryUrlPathGenerator\Proxy $categoryUrlPathGenerator,
+        UrlPersistInterface\Proxy $urlPersist,
+        EventManager\Proxy $eventManager,
+        CategoryResource\Proxy $categoryResource,
+        Emulation\Proxy $emulation
     ) {
         $this->state = $state;
         $this->categoryUrlPathGenerator = $categoryUrlPathGenerator;

--- a/Iazel/RegenProductUrl/Console/Command/RegenerateCategoryPathCommand.php
+++ b/Iazel/RegenProductUrl/Console/Command/RegenerateCategoryPathCommand.php
@@ -129,8 +129,8 @@ class RegenerateCategoryPathCommand extends Command
         {
             $out->writeln('Regenerating urls for ' . $category->getName() . ' (' . $category->getId() . ')');
 
-            $category->setOrigData('url_key', mt_rand(0,1000)); // set url_key in orig data to random value to force regeneration of path
-            $category->setOrigData('url_path', mt_rand(0,1000)); // set url_path in orig data to random value to force regeneration of path for children
+            $category->setOrigData('url_key', mt_rand(1,1000)); // set url_key in orig data to random value to force regeneration of path
+            $category->setOrigData('url_path', mt_rand(1,1000)); // set url_path in orig data to random value to force regeneration of path for children
 
             // Make use of Magento's event for this
             $this->emulation->startEnvironmentEmulation($store_id, Area::AREA_FRONTEND, true);

--- a/Iazel/RegenProductUrl/Console/Command/RegenerateCategoryPathCommand.php
+++ b/Iazel/RegenProductUrl/Console/Command/RegenerateCategoryPathCommand.php
@@ -1,7 +1,11 @@
 <?php
 namespace Iazel\RegenProductUrl\Console\Command;
 
+use Magento\Catalog\Model\ResourceModel\Category as CategoryResource;
+use Magento\Framework\App\Area;
+use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\EntityManager\EventManager;
+use Magento\Store\Model\App\Emulation;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
@@ -34,6 +38,7 @@ class RegenerateCategoryPathCommand extends Command
      * @var \Magento\Framework\App\State
      */
     protected $state;
+
     /**
      * @var CategoryCollectionFactory
      */
@@ -42,13 +47,34 @@ class RegenerateCategoryPathCommand extends Command
      * @var EventManager
      */
     private $eventManager;
+    /**
+     * @var CategoryResource
+     */
+    private $categoryResource;
+    /**
+     * @var Emulation
+     */
+    private $emulation;
 
+    /**
+     * RegenerateCategoryPathCommand constructor.
+     * @param State $state
+     * @param CategoryCollectionFactory $categoryCollectionFactory
+     * @param CategoryUrlPathGenerator $categoryUrlPathGenerator
+     * @param UrlPersistInterface $urlPersist
+     * @param EventManager $eventManager
+     * @param CategoryResource $categoryResource
+     * @param ResourceConnection $resource
+     * @param Emulation $emulation
+     */
     public function __construct(
         State $state,
         CategoryCollectionFactory $categoryCollectionFactory,
         CategoryUrlPathGenerator $categoryUrlPathGenerator,
         UrlPersistInterface $urlPersist,
-        EventManager $eventManager
+        EventManager $eventManager,
+        CategoryResource $categoryResource,
+        Emulation $emulation
     ) {
         $this->state = $state;
         $this->categoryUrlPathGenerator = $categoryUrlPathGenerator;
@@ -56,6 +82,8 @@ class RegenerateCategoryPathCommand extends Command
         parent::__construct();
         $this->categoryCollectionFactory = $categoryCollectionFactory;
         $this->eventManager = $eventManager;
+        $this->categoryResource = $categoryResource;
+        $this->emulation = $emulation;
     }
 
     protected function configure()
@@ -101,8 +129,14 @@ class RegenerateCategoryPathCommand extends Command
         {
             $out->writeln('Regenerating urls for ' . $category->getName() . ' (' . $category->getId() . ')');
 
+            $category->setOrigData('url_key', mt_rand(0,1000)); // set url_key in orig data to random value to force regeneration of path
+            $category->setOrigData('url_path', mt_rand(0,1000)); // set url_path in orig data to random value to force regeneration of path for children
+
             // Make use of Magento's event for this
+            $this->emulation->startEnvironmentEmulation($store_id, Area::AREA_FRONTEND, true);
             $this->eventManager->dispatch('regenerate_category_url_path', ['category' => $category]);
+            $this->emulation->stopEnvironmentEmulation();
+
             $regenerated++;
         }
 

--- a/Iazel/RegenProductUrl/Console/Command/RegenerateCategoryUrlCommand.php
+++ b/Iazel/RegenProductUrl/Console/Command/RegenerateCategoryUrlCommand.php
@@ -19,17 +19,17 @@ use Magento\Framework\App\State;
 class RegenerateCategoryUrlCommand extends Command
 {
     /**
-     * @var CategoryUrlRewriteGenerator
+     * @var CategoryUrlRewriteGenerator\Proxy
      */
     protected $categoryUrlRewriteGenerator;
 
     /**
-     * @var UrlPersistInterface
+     * @var UrlPersistInterface\Proxy
      */
     protected $urlPersist;
 
     /**
-     * @var CategoryRepositoryInterface
+     * @var CategoryRepositoryInterface\Proxy
      */
     protected $collection;
 
@@ -37,31 +37,33 @@ class RegenerateCategoryUrlCommand extends Command
      * @var \Magento\Framework\App\State
      */
     protected $state;
+    
     /**
-     * @var CategoryCollectionFactory
+     * @var CategoryCollectionFactory\Proxy
      */
     private $categoryCollectionFactory;
+    
     /**
-     * @var Emulation
+     * @var Emulation\Proxy
      */
     private $emulation;
 
     /**
      * RegenerateCategoryUrlCommand constructor.
      * @param State $state
-     * @param Collection $collection
-     * @param CategoryUrlRewriteGenerator $categoryUrlRewriteGenerator
-     * @param UrlPersistInterface $urlPersist
-     * @param CategoryCollectionFactory $categoryCollectionFactory
-     * @param Emulation $emulation
+     * @param Collection\Proxy $collection
+     * @param CategoryUrlRewriteGenerator\Proxy $categoryUrlRewriteGenerator
+     * @param UrlPersistInterface\Proxy $urlPersist
+     * @param CategoryCollectionFactory\Proxy $categoryCollectionFactory
+     * @param Emulation\Proxy $emulation
      */
     public function __construct(
         State $state,
-        Collection $collection,
-        CategoryUrlRewriteGenerator $categoryUrlRewriteGenerator,
-        UrlPersistInterface $urlPersist,
-        CategoryCollectionFactory $categoryCollectionFactory,
-        Emulation $emulation
+        Collection\Proxy $collection,
+        CategoryUrlRewriteGenerator\Proxy $categoryUrlRewriteGenerator,
+        UrlPersistInterface\Proxy $urlPersist,
+        CategoryCollectionFactory\Proxy $categoryCollectionFactory,
+        Emulation\Proxy $emulation
     ) {
         $this->state = $state;
         $this->collection = $collection;

--- a/Iazel/RegenProductUrl/Console/Command/RegenerateCategoryUrlCommand.php
+++ b/Iazel/RegenProductUrl/Console/Command/RegenerateCategoryUrlCommand.php
@@ -126,6 +126,7 @@ class RegenerateCategoryUrlCommand extends Command
 
             $newUrls = $this->categoryUrlRewriteGenerator->generate($category);
             try {
+                $newUrls = $this->filterEmptyRequestPaths($newUrls);
                 $this->urlPersist->replace($newUrls);
                 $regenerated += count($newUrls);
             }
@@ -136,4 +137,22 @@ class RegenerateCategoryUrlCommand extends Command
         $this->emulation->stopEnvironmentEmulation();
         $out->writeln('Done regenerating. Regenerated ' . $regenerated . ' urls');
     }
+    
+    /**
+     * Remove entries with request_path='' to prevent error 404 for "http://site.com/" address.
+     *
+     * @param \Magento\UrlRewrite\Service\V1\Data\UrlRewrite[] $newUrls
+     * @return \Magento\UrlRewrite\Service\V1\Data\UrlRewrite[]
+     */
+    private function filterEmptyRequestPaths($newUrls)
+    {
+        $result = [];
+        foreach ($newUrls as $key => $url) {
+            $requestPath = $url->getRequestPath();
+            if (!empty($requestPath)) {
+                $result[$key] = $url;
+            }
+        }
+        return $result;
+    }    
 }

--- a/Iazel/RegenProductUrl/Console/Command/RegenerateCategoryUrlCommand.php
+++ b/Iazel/RegenProductUrl/Console/Command/RegenerateCategoryUrlCommand.php
@@ -1,0 +1,113 @@
+<?php
+namespace Iazel\RegenProductUrl\Console\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Magento\UrlRewrite\Service\V1\Data\UrlRewrite;
+use Magento\UrlRewrite\Model\UrlPersistInterface;
+use Magento\CatalogUrlRewrite\Model\CategoryUrlRewriteGenerator;
+use Magento\Catalog\Model\ResourceModel\Category\Collection;
+use Magento\Store\Model\Store;
+use Magento\Framework\App\State;
+
+class RegenerateCategoryUrlCommand extends Command
+{
+    /**
+     * @var CategoryUrlRewriteGenerator
+     */
+    protected $categoryUrlRewriteGenerator;
+
+    /**
+     * @var UrlPersistInterface
+     */
+    protected $urlPersist;
+
+    /**
+     * @var CategoryRepositoryInterface
+     */
+    protected $collection;
+
+    /**
+     * @var \Magento\Framework\App\State
+     */
+    protected $state;
+
+    public function __construct(
+        State $state,
+        Collection $collection,
+        CategoryUrlRewriteGenerator $categoryUrlRewriteGenerator,
+        UrlPersistInterface $urlPersist
+    ) {
+        $this->state = $state;
+        $this->collection = $collection;
+        $this->categoryUrlRewriteGenerator = $categoryUrlRewriteGenerator;
+        $this->urlPersist = $urlPersist;
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this->setName('iazel:regenurl:category')
+            ->setDescription('Regenerate url for given categories')
+            ->addArgument(
+                'cids',
+                InputArgument::IS_ARRAY,
+                'Categories to regenerate'
+            )
+            ->addOption(
+                'store', 's',
+                InputOption::VALUE_REQUIRED,
+                'Use the specific Store View',
+                Store::DEFAULT_STORE_ID
+            )
+        ;
+        return parent::configure();
+    }
+
+    public function execute(InputInterface $inp, OutputInterface $out)
+    {
+        try{
+            $this->state->getAreaCode();
+        }catch ( \Magento\Framework\Exception\LocalizedException $e){
+            $this->state->setAreaCode('adminhtml');
+        }
+
+        $store_id = $inp->getOption('store');
+        //$this->collection->addStoreFilter($store_id)->setStoreId($store_id);
+
+        $cids = $inp->getArgument('cids');
+        if( !empty($cids) )
+            $this->collection->addIdFilter($cids);
+
+        $this->collection->addAttributeToSelect(['name', 'url_path', 'url_key']);
+        $list = $this->collection->load();
+        $regenerated = 0;
+        foreach($list as $category)
+        {
+            $out->writeln('Regenerating urls for ' . $category->getName() . ' (' . $category->getId() . ')');
+            if($store_id !== Store::DEFAULT_STORE_ID) {
+                $category->setStoreId($store_id);
+            }
+
+            $this->urlPersist->deleteByData([
+                UrlRewrite::ENTITY_ID => $category->getId(),
+                UrlRewrite::ENTITY_TYPE => CategoryUrlRewriteGenerator::ENTITY_TYPE,
+                UrlRewrite::REDIRECT_TYPE => 0,
+                UrlRewrite::STORE_ID => $store_id
+            ]);
+
+            $newUrls = $this->categoryUrlRewriteGenerator->generate($category);
+            try {
+                $this->urlPersist->replace($newUrls);
+                $regenerated += count($newUrls);
+            }
+            catch(\Exception $e) {
+                $out->writeln(sprintf('<error>Duplicated url for store ID %d, category %d (%s) - %s Generated URLs:' . PHP_EOL . '%s</error>' . PHP_EOL, $store_id, $category->getId(), $category->getName(), $e->getMessage(), implode(PHP_EOL, array_keys($newUrls))));
+            }
+        }
+        $out->writeln('Done regenerating. Regenerated ' . $regenerated . ' urls');
+    }
+}

--- a/Iazel/RegenProductUrl/Console/Command/RegenerateProductUrlCommand.php
+++ b/Iazel/RegenProductUrl/Console/Command/RegenerateProductUrlCommand.php
@@ -104,7 +104,10 @@ class RegenerateProductUrlCommand extends Command
                 continue;
             }
 
-            $this->collection->addStoreFilter($store_id)->setStoreId($store_id);
+            $this->collection
+                ->addStoreFilter($store_id)
+                ->setStoreId($store_id)
+                ->addFieldToFilter('visibility', ['gt' => Visibility::VISIBILITY_NOT_VISIBLE]);
 
             $pids = $inp->getArgument('pids');
             if (!empty($pids)) {

--- a/Iazel/RegenProductUrl/Console/Command/RegenerateProductUrlCommand.php
+++ b/Iazel/RegenProductUrl/Console/Command/RegenerateProductUrlCommand.php
@@ -109,8 +109,8 @@ class RegenerateProductUrlCommand extends Command
             }
 
             $this->collection
-                ->addStoreFilter($storeId)
-                ->setStoreId($storeId)
+                ->addStoreFilter($store->getId())
+                ->setStoreId($store->getId())
                 ->addFieldToFilter('visibility', ['gt' => Visibility::VISIBILITY_NOT_VISIBLE]);
 
             $pids = $input->getArgument('pids');
@@ -125,13 +125,13 @@ class RegenerateProductUrlCommand extends Command
             /** @var \Magento\Catalog\Model\Product $product */
             foreach ($list as $product) {
                 echo 'Regenerating urls for ' . $product->getSku() . ' (' . $product->getId() . ') in store ' . $store->getName() . PHP_EOL;
-                $product->setStoreId($storeId);
+                $product->setStoreId($store->getId());
 
                 $this->urlPersist->deleteByData([
                     UrlRewrite::ENTITY_ID => $product->getId(),
                     UrlRewrite::ENTITY_TYPE => ProductUrlRewriteGenerator::ENTITY_TYPE,
                     UrlRewrite::REDIRECT_TYPE => 0,
-                    UrlRewrite::STORE_ID => $storeId
+                    UrlRewrite::STORE_ID => $store->getId()
                 ]);
 
                 $newUrls = $this->productUrlRewriteGenerator->generate($product);
@@ -139,7 +139,7 @@ class RegenerateProductUrlCommand extends Command
                     $this->urlPersist->replace($newUrls);
                     $regenerated += count($newUrls);
                 } catch (\Exception $e) {
-                    $output->writeln(sprintf('<error>Duplicated url for store ID %d, product %d (%s) - %s Generated URLs:' . PHP_EOL . '%s</error>' . PHP_EOL, $storeId, $product->getId(), $product->getSku(), $e->getMessage(), implode(PHP_EOL, array_keys($newUrls))));
+                    $output->writeln(sprintf('<error>Duplicated url for store ID %d, product %d (%s) - %s Generated URLs:' . PHP_EOL . '%s</error>' . PHP_EOL, $store->getId(), $product->getId(), $product->getSku(), $e->getMessage(), implode(PHP_EOL, array_keys($newUrls))));
                 }
             }
             $output->writeln('Done regenerating. Regenerated ' . $regenerated . ' urls for store ' . $store->getName());

--- a/Iazel/RegenProductUrl/Console/Command/RegenerateProductUrlCommand.php
+++ b/Iazel/RegenProductUrl/Console/Command/RegenerateProductUrlCommand.php
@@ -50,7 +50,7 @@ class RegenerateProductUrlCommand extends Command
 
     protected function configure()
     {
-        $this->setName('iazel:regenurl')
+        $this->setName('regenerate:product:url')
             ->setDescription('Regenerate url for given products')
             ->addArgument(
                 'pids',

--- a/Iazel/RegenProductUrl/Console/Command/RegenerateProductUrlCommand.php
+++ b/Iazel/RegenProductUrl/Console/Command/RegenerateProductUrlCommand.php
@@ -69,7 +69,9 @@ class RegenerateProductUrlCommand extends Command
 
     public function execute(InputInterface $inp, OutputInterface $out)
     {
-        if (!$this->state->getAreaCode()) {
+        try{
+            $this->state->getAreaCode();
+        }catch ( \Magento\Framework\Exception\LocalizedException $e){
             $this->state->setAreaCode('adminhtml');
         }
 
@@ -84,7 +86,7 @@ class RegenerateProductUrlCommand extends Command
         $list = $this->collection->load();
         foreach($list as $product)
         {
-            if($store_id === Store::DEFAULT_STORE_ID)
+            if($store_id !== Store::DEFAULT_STORE_ID)
                 $product->setStoreId($store_id);
 
             $this->urlPersist->deleteByData([

--- a/Iazel/RegenProductUrl/Console/Command/RegenerateProductUrlCommand.php
+++ b/Iazel/RegenProductUrl/Console/Command/RegenerateProductUrlCommand.php
@@ -18,17 +18,17 @@ use Magento\Framework\App\State;
 class RegenerateProductUrlCommand extends Command
 {
     /**
-     * @var ProductUrlRewriteGenerator
+     * @var ProductUrlRewriteGenerator\Proxy
      */
     protected $productUrlRewriteGenerator;
 
     /**
-     * @var UrlPersistInterface
+     * @var UrlPersistInterface\Proxy
      */
     protected $urlPersist;
 
     /**
-     * @var Collection
+     * @var Collection\Proxy
      */
     protected $collection;
 
@@ -36,25 +36,26 @@ class RegenerateProductUrlCommand extends Command
      * @var \Magento\Framework\App\State
      */
     protected $state;
+    
     /**
-     * @var StoreManagerInterface
+     * @var StoreManagerInterface\Proxy
      */
     private $storeManager;
 
     /**
      * RegenerateProductUrlCommand constructor.
      * @param State $state
-     * @param Collection $collection
-     * @param ProductUrlRewriteGenerator $productUrlRewriteGenerator
-     * @param UrlPersistInterface $urlPersist
-     * @param StoreManagerInterface $storeManager
+     * @param Collection\Proxy $collection
+     * @param ProductUrlRewriteGenerator\Proxy $productUrlRewriteGenerator
+     * @param UrlPersistInterface\Proxy $urlPersist
+     * @param StoreManagerInterface\Proxy $storeManager
      */
     public function __construct(
         State $state,
-        Collection $collection,
-        ProductUrlRewriteGenerator $productUrlRewriteGenerator,
-        UrlPersistInterface $urlPersist,
-        StoreManagerInterface $storeManager
+        Collection\Proxy $collection,
+        ProductUrlRewriteGenerator\Proxy $productUrlRewriteGenerator,
+        UrlPersistInterface\Proxy $urlPersist,
+        StoreManagerInterface\Proxy $storeManager
     ) {
         $this->state = $state;
         $this->collection = $collection;

--- a/Iazel/RegenProductUrl/Console/Command/RegenerateProductUrlCommand.php
+++ b/Iazel/RegenProductUrl/Console/Command/RegenerateProductUrlCommand.php
@@ -1,6 +1,8 @@
 <?php
 namespace Iazel\RegenProductUrl\Console\Command;
 
+use Magento\Store\Model\StoreManager;
+use Magento\Store\Model\StoreManagerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
@@ -34,18 +36,32 @@ class RegenerateProductUrlCommand extends Command
      * @var \Magento\Framework\App\State
      */
     protected $state;
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
 
+    /**
+     * RegenerateProductUrlCommand constructor.
+     * @param State $state
+     * @param Collection $collection
+     * @param ProductUrlRewriteGenerator $productUrlRewriteGenerator
+     * @param UrlPersistInterface $urlPersist
+     * @param StoreManagerInterface $storeManager
+     */
     public function __construct(
         State $state,
         Collection $collection,
         ProductUrlRewriteGenerator $productUrlRewriteGenerator,
-        UrlPersistInterface $urlPersist
+        UrlPersistInterface $urlPersist,
+        StoreManagerInterface $storeManager
     ) {
         $this->state = $state;
         $this->collection = $collection;
         $this->productUrlRewriteGenerator = $productUrlRewriteGenerator;
         $this->urlPersist = $urlPersist;
         parent::__construct();
+        $this->storeManager = $storeManager;
     }
 
     protected function configure()
@@ -76,37 +92,59 @@ class RegenerateProductUrlCommand extends Command
         }
 
         $store_id = $inp->getOption('store');
-        $this->collection->addStoreFilter($store_id)->setStoreId($store_id);
+        $stores = $this->storeManager->getStores(false);
 
-        $pids = $inp->getArgument('pids');
-        if( !empty($pids) )
-            $this->collection->addIdFilter($pids);
+        if (!is_numeric($store_id)) {
+            $store_id = $this->getStoreIdByCode($store_id, $stores);
+        }
 
-        $this->collection->addAttributeToSelect(['url_path', 'url_key']);
-        $list = $this->collection->load();
-        $regenerated = 0;
-        foreach($list as $product)
-        {
-            $out->writeln('Regenerating urls for ' . $product->getSku() . ' (' . $product->getId() . ')');
-            if($store_id !== Store::DEFAULT_STORE_ID)
+        foreach ($stores as $store) {
+            // If store has been given through option, skip other stores
+            if ($store_id != Store::DEFAULT_STORE_ID AND $store->getId() != $store_id) {
+                continue;
+            }
+
+            $this->collection->addStoreFilter($store_id)->setStoreId($store_id);
+
+            $pids = $inp->getArgument('pids');
+            if (!empty($pids)) {
+                $this->collection->addIdFilter($pids);
+            }
+
+            $this->collection->addAttributeToSelect(['url_path', 'url_key']);
+            $list = $this->collection->load();
+            $regenerated = 0;
+            foreach ($list as $product) {
+                echo 'Regenerating urls for ' . $product->getSku() . ' (' . $product->getId() . ') in store ' . $store->getName() . PHP_EOL;
                 $product->setStoreId($store_id);
 
-            $this->urlPersist->deleteByData([
-                UrlRewrite::ENTITY_ID => $product->getId(),
-                UrlRewrite::ENTITY_TYPE => ProductUrlRewriteGenerator::ENTITY_TYPE,
-                UrlRewrite::REDIRECT_TYPE => 0,
-                UrlRewrite::STORE_ID => $store_id
-            ]);
+                $this->urlPersist->deleteByData([
+                    UrlRewrite::ENTITY_ID => $product->getId(),
+                    UrlRewrite::ENTITY_TYPE => ProductUrlRewriteGenerator::ENTITY_TYPE,
+                    UrlRewrite::REDIRECT_TYPE => 0,
+                    UrlRewrite::STORE_ID => $store_id
+                ]);
 
-            $newUrls = $this->productUrlRewriteGenerator->generate($product);
-            try {
-                $this->urlPersist->replace($newUrls);
-                $regenerated += count($newUrls);
+                $newUrls = $this->productUrlRewriteGenerator->generate($product);
+                try {
+                    $this->urlPersist->replace($newUrls);
+                    $regenerated += count($newUrls);
+                } catch (\Exception $e) {
+                    $out->writeln(sprintf('<error>Duplicated url for store ID %d, product %d (%s) - %s Generated URLs:' . PHP_EOL . '%s</error>' . PHP_EOL, $store_id, $product->getId(), $product->getSku(), $e->getMessage(), implode(PHP_EOL, array_keys($newUrls))));
+                }
             }
-            catch(\Exception $e) {
-                $out->writeln(sprintf('<error>Duplicated url for store ID %d, product %d (%s) - %s Generated URLs:' . PHP_EOL . '%s</error>' . PHP_EOL, $store_id, $product->getId(), $product->getSku(), $e->getMessage(), implode(PHP_EOL, array_keys($newUrls))));
+            $out->writeln('Done regenerating. Regenerated ' . $regenerated . ' urls for store ' . $store->getName());
+        }
+    }
+
+    private function getStoreIdByCode($store_id, $stores)
+    {
+        foreach ($stores as $store) {
+            if ($store->getCode() == $store_id) {
+                return $store->getId();
             }
         }
-        $out->writeln('Done regenerating. Regenerated ' . $regenerated . ' urls');
+
+        return Store::DEFAULT_STORE_ID;
     }
 }

--- a/Iazel/RegenProductUrl/Console/Command/RegenerateProductUrlCommand.php
+++ b/Iazel/RegenProductUrl/Console/Command/RegenerateProductUrlCommand.php
@@ -108,7 +108,7 @@ class RegenerateProductUrlCommand extends Command
             if ($storeId != Store::DEFAULT_STORE_ID AND $store->getId() != $storeId) {
                 continue;
             }
-
+            $this->collection->clear();
             $this->collection
                 ->addStoreFilter($store->getId())
                 ->setStoreId($store->getId())

--- a/Iazel/RegenProductUrl/Model/CategoryUrlPathGenerator.php
+++ b/Iazel/RegenProductUrl/Model/CategoryUrlPathGenerator.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Iazel\RegenProductUrl\Model;
+
+class CategoryUrlPathGenerator extends \Magento\CatalogUrlRewrite\Model\CategoryUrlPathGenerator
+{
+
+    /**
+     * @param \Magento\Catalog\Model\Category $category
+     * @return bool
+     */
+    protected function isNeedToGenerateUrlPathForParent($category)
+    {
+        /* Force true when command is run from the CLI */
+        if (PHP_SAPI == 'cli') {
+            return true;
+        }
+
+        return $category->isObjectNew() || $category->getLevel() >= self::MINIMAL_CATEGORY_LEVEL_FOR_PROCESSING;
+    }
+}

--- a/Iazel/RegenProductUrl/etc/di.xml
+++ b/Iazel/RegenProductUrl/etc/di.xml
@@ -10,6 +10,7 @@
         <arguments>
             <argument name="commands" xsi:type="array">
                 <item name="product_url_regeneration_command" xsi:type="object">Iazel\RegenProductUrl\Console\Command\RegenerateProductUrlCommand</item>
+                <item name="category_url_regeneration_command" xsi:type="object">Iazel\RegenProductUrl\Console\Command\RegenerateCategoryUrlCommand</item>
             </argument>
         </arguments>
     </type>

--- a/Iazel/RegenProductUrl/etc/di.xml
+++ b/Iazel/RegenProductUrl/etc/di.xml
@@ -11,6 +11,7 @@
             <argument name="commands" xsi:type="array">
                 <item name="product_url_regeneration_command" xsi:type="object">Iazel\RegenProductUrl\Console\Command\RegenerateProductUrlCommand</item>
                 <item name="category_url_regeneration_command" xsi:type="object">Iazel\RegenProductUrl\Console\Command\RegenerateCategoryUrlCommand</item>
+                <item name="category_path_regeneration_command" xsi:type="object">Iazel\RegenProductUrl\Console\Command\RegenerateCategoryPathCommand</item>
             </argument>
         </arguments>
     </type>

--- a/Iazel/RegenProductUrl/etc/di.xml
+++ b/Iazel/RegenProductUrl/etc/di.xml
@@ -15,4 +15,5 @@
             </argument>
         </arguments>
     </type>
+    <preference for="Magento\CatalogUrlRewrite\Model\CategoryUrlPathGenerator" type="Iazel\RegenProductUrl\Model\CategoryUrlPathGenerator" />
 </config>

--- a/Iazel/RegenProductUrl/etc/events.xml
+++ b/Iazel/RegenProductUrl/etc/events.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
+    <event name="regenerate_category_url_path">
+        <observer name="category_url_path_autogeneration" instance="Magento\CatalogUrlRewrite\Observer\CategoryUrlPathAutogeneratorObserver"/>
+    </event>
+</config>

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ This extension adds console commands to be able to regenerate;
 Using Composer;
 
 ```sh
-composer config repositories.regenurl vcs git@github.com:elgentos/regenerate-catalog-urls.git
 composer require elgentos/regenerate-catalog-urls
 php bin/magento setup:upgrade
 ```

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ This extension adds console commands to be able to regenerate;
 Using Composer;
 
 ```sh
-composer config repositories.regenurl vcs git@github.com:peterjaap/magento2-regenurl.git
-composer require iazel/module-regen-product-url
+composer config repositories.regenurl vcs git@github.com:elgentos/magento2-regenurl.git
+composer require elgentos/module-regen-product-url
 php bin/magento setup:upgrade
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+# What does it do
+This extension adds console commands to be able to regenerate;
+
+- a product rewrite URL based on its url path;
+- a category rewrite URL based on its url path;
+- a category URL path based on its URL key and its parent categories.
+
 # Install
 Download and copy the `Iazel` directory into `app/code/` or install using composer
 
@@ -13,10 +20,13 @@ php bin/magento setup:upgrade
 # How to use
 ```
 Usage:
- iazel:regenurl [-s|--store="..."] [pids1] ... [pidsN]
+ regenerate:product:url [-s|--store="..."] [pids1] ... [pidsN]
+ regenerate:category:url [-s]--store="..."] [cids1] ... [cidsN]
+ regenerate:category:path [-s]--store="..."] [cids1] ... [cidsN]
 
 Arguments:
  pids                  Products to regenerate
+ cids                  Categories to regenerate
 
 Options:
  --store (-s)          Use the specific Store View (default: 0)
@@ -26,8 +36,8 @@ Options:
 Eg:
 ```sh
 # Regenerate url for all products and the global store
-php bin/magento iazel:regenurl
+php bin/magento regenerate:product
 
 # Regenerate url for products with id (1, 2, 3, 4) for store 1
-php bin/magento iazel:regenurl -s1 1 2 3 4
+php bin/magento regenerate:product:url -s1 1 2 3 4
 ```

--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ Using Composer;
 
 ```sh
 composer require elgentos/regenerate-catalog-urls
+php bin/magento module:enable Iazel_RegenProductUrl
 php bin/magento setup:upgrade
 ```
 
-Or download and copy the `Iazel` directory into `app/code/` and run `php bin/magento setup:upgrade`.
+Or download and copy the `Iazel` directory into `app/code/`, enable the module and run `php bin/magento setup:upgrade`.
 
 # How to use
 ```
@@ -34,7 +35,7 @@ Options:
 Eg:
 ```sh
 # Regenerate url for all products and the global store
-php bin/magento regenerate:product
+php bin/magento regenerate:product:url
 
 # Regenerate url for products with id (1, 2, 3, 4) for store 1
 php bin/magento regenerate:product:url -s1 1 2 3 4

--- a/README.md
+++ b/README.md
@@ -6,16 +6,15 @@ This extension adds console commands to be able to regenerate;
 - a category URL path based on its URL key and its parent categories.
 
 # Install
-Download and copy the `Iazel` directory into `app/code/` or install using composer
+Using Composer;
 
 ```sh
-composer require iazel/module-regen-product-url 
-```
-
-Then call:
-```sh
+composer config repositories.regenurl vcs git@github.com:peterjaap/magento2-regenurl.git
+composer require iazel/module-regen-product-url
 php bin/magento setup:upgrade
 ```
+
+Or download and copy the `Iazel` directory into `app/code/` and run `php bin/magento setup:upgrade`.
 
 # How to use
 ```

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ This extension adds console commands to be able to regenerate;
 Using Composer;
 
 ```sh
-composer config repositories.regenurl vcs git@github.com:elgentos/magento2-regenurl.git
-composer require elgentos/module-regen-product-url
+composer config repositories.regenurl vcs git@github.com:elgentos/regenerate-catalog-urls.git
+composer require elgentos/regenerate-catalog-urls
 php bin/magento setup:upgrade
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -19,5 +19,8 @@
     "psr-4": {
       "Iazel\\RegenProductUrl\\": "Iazel/RegenProductUrl"
     }
+  },
+  "replace": {
+    "iazel/module-regen-product-url": "*"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,6 @@
     "magento/magento-composer-installer": "*"
   },
   "type": "magento2-module",
-  "version": "1.0.0.1",
   "license": [
     "OSL-3.0",
     "AFL-3.0"

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "iazel/module-regen-product-url",
   "description": "N/A",
   "require": {
-    "php": "~5.6.0|~7.0",
+    "php": "~5.6.0|~7.0|~7.1|~7.2",
     "magento/framework": ">=100.1",
     "magento/module-catalog-url-rewrite": ">=100.1",
     "magento/magento-composer-installer": "*"

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "iazel/module-regen-product-url",
+  "name": "elgentos/module-regen-product-url",
   "description": "N/A",
   "require": {
     "php": "~5.6.0|~7.0|~7.1|~7.2",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "elgentos/module-regen-product-url",
+  "name": "elgentos/regenerate-catalog-urls",
   "description": "N/A",
   "require": {
     "php": "~5.6.0|~7.0|~7.1|~7.2",

--- a/composer.json
+++ b/composer.json
@@ -3,12 +3,12 @@
   "description": "N/A",
   "require": {
     "php": "~5.6.0|~7.0",
-    "magento/framework": "100.1.*",
-    "magento/module-catalog-url-rewrite": "100.1.*",
+    "magento/framework": ">=100.1",
+    "magento/module-catalog-url-rewrite": ">=100.1",
     "magento/magento-composer-installer": "*"
   },
   "type": "magento2-module",
-  "version": "1.0.0",
+  "version": "1.0.0.1",
   "license": [
     "OSL-3.0",
     "AFL-3.0"


### PR DESCRIPTION
There was an issue where when generating the url_rewrite entries for all store views at the same time, for products. I would get the same request paths for different store views, despite the product url_keys differing across store views. This fixed it. I am relatively new to Magento though so perhaps this edit is not ideal.